### PR TITLE
Fixed validity check on property alfviral.file.only_or_exceptions

### DIFF
--- a/alfviral/src/main/java/com/fegor/alfresco/services/AntivirusServiceImpl.java
+++ b/alfviral/src/main/java/com/fegor/alfresco/services/AntivirusServiceImpl.java
@@ -248,8 +248,8 @@ public class AntivirusServiceImpl implements AntivirusService {
 				}
 			}
 
-			else if ((!(fileOnlyOrExceptions.toLowerCase()).equals(fileOnly))
-					|| (!(fileOnlyOrExceptions.toLowerCase()).equals(fileExceptions))) {
+			else if ((!(fileOnlyOrExceptions.toLowerCase()).equals(FILE_ONLY))
+					|| (!(fileOnlyOrExceptions.toLowerCase()).equals(FILE_EXCEPTIONS))) {
 				logger.error("Property alfviral.file.only_or_exceptions not is '" + FILE_ONLY + "' or '"
 						+ FILE_EXCEPTIONS + "'");
 			}


### PR DESCRIPTION
Fixes #10 

The validity check on the property `alfviral.file.only_or_exceptions` checks against the wrong values. This results in incorrect error messages. This change fixes this validity-check.