### PR TITLE
Added possibility to deny upload of infected nodes on content update

### DIFF
--- a/alfviral/pom.xml
+++ b/alfviral/pom.xml
@@ -80,7 +80,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.4.4</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
 		<dependency>
 		    <groupId>org.apache.commons</groupId>

--- a/alfviral/src/main/amp/config/alfresco/subsystems/Security/alfviral/alfviral-context.xml
+++ b/alfviral/src/main/amp/config/alfresco/subsystems/Security/alfviral/alfviral-context.xml
@@ -218,6 +218,9 @@
         <property name="onUpdate">
             <value>${alfviral.on_update}</value>
         </property>
+        <property name="deleteOnUpdate">
+            <value>${alfviral.on_update.delete}</value>
+        </property>
         <property name="onRead">
             <value>${alfviral.on_read}</value>
         </property>

--- a/alfviral/src/main/amp/config/alfresco/subsystems/Security/alfviral/alfviral.properties
+++ b/alfviral/src/main/amp/config/alfresco/subsystems/Security/alfviral/alfviral.properties
@@ -22,6 +22,8 @@ alfviral.mode=ICAP
 # Events
 alfviral.on_update=TRUE
 alfviral.on_read=FALSE
+# Delete node on content update if the content-file is infected
+alfviral.on_update.delete=false
 
 # Scheduled action
 alfviral.scheduled.pathQuery=/app:company_home/st:sites

--- a/alfviral/src/main/java/com/fegor/alfresco/behavior/OnUpdateReadScan.java
+++ b/alfviral/src/main/java/com/fegor/alfresco/behavior/OnUpdateReadScan.java
@@ -65,6 +65,7 @@ public class OnUpdateReadScan implements
 	 */
 	private boolean on_update;
 	private boolean on_read;
+	private boolean deleteOnUpdate;
 
 	/**
 	 * Init method; policies definitions and bindings
@@ -121,6 +122,10 @@ public class OnUpdateReadScan implements
 							+ ": [In onContentUpdate: " + nodeRef
 							+ " is infected]");
 				}
+
+				if (deleteOnUpdate) {
+					deleteInfectedNode(nodeRef);
+				}
 			}
 		}
 
@@ -128,6 +133,12 @@ public class OnUpdateReadScan implements
 			logger.debug("NodeRef Id: " + nodeRef.getId().toString()
 					+ " has deleted (update event)");
 		}
+	}
+
+	private void deleteInfectedNode(final NodeRef nodeRef) {
+		logger.info("Delete infected node " + nodeRef);
+		nodeService.addAspect(nodeRef, ContentModel.ASPECT_TEMPORARY, null);
+		nodeService.deleteNode(nodeRef);
 	}
 
 	/*
@@ -191,5 +202,19 @@ public class OnUpdateReadScan implements
 	 */
 	public void setOnRead(boolean on_read) {
 		this.on_read = on_read;
+	}
+
+	/**
+	 * @return deleteOnUpdate
+	 */
+	public boolean isDeleteOnUpdate() {
+		return deleteOnUpdate;
+	}
+
+	/**
+	 * @param deleteOnUpdate
+	 */
+	public void setDeleteOnUpdate(boolean deleteOnUpdate) {
+		this.deleteOnUpdate = deleteOnUpdate;
 	}
 }

--- a/alfviral/src/test/java/com/fegor/alfresco/behavior/OnUpdateReadScanTest.java
+++ b/alfviral/src/test/java/com/fegor/alfresco/behavior/OnUpdateReadScanTest.java
@@ -1,0 +1,73 @@
+package com.fegor.alfresco.behavior;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.alfresco.service.cmr.action.ActionService;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.fegor.alfresco.model.AlfviralModel;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OnUpdateReadScanTest {
+
+	private OnUpdateReadScan onUpdateReadScan;
+
+	private NodeRef testNode;
+
+	@Mock
+	private ActionService actionService;
+	@Mock
+	private NodeService nodeService;
+
+	@Before
+	public void setup() {
+		onUpdateReadScan = new OnUpdateReadScan();
+		onUpdateReadScan.setActionService(actionService);
+		onUpdateReadScan.setNodeService(nodeService);
+		testNode = new NodeRef("workspace://TestStore/test");
+	}
+
+	@Test
+	public void testDeleteOnContentUpdate() {
+		onUpdateReadScan.setDeleteOnUpdate(true);
+
+		when(nodeService.exists(testNode)).thenReturn(true);
+		when(nodeService.hasAspect(testNode, AlfviralModel.ASPECT_INFECTED)).thenReturn(true);
+
+		onUpdateReadScan.onContentUpdate(testNode, true);
+
+		verify(nodeService).deleteNode(testNode);
+	}
+
+	@Test
+	public void testDeleteOnContentUpdateDeactivated() {
+		onUpdateReadScan.setDeleteOnUpdate(false);
+
+		when(nodeService.exists(testNode)).thenReturn(true);
+		when(nodeService.hasAspect(testNode, AlfviralModel.ASPECT_INFECTED)).thenReturn(true);
+
+		onUpdateReadScan.onContentUpdate(testNode, true);
+
+		verify(nodeService, Mockito.never()).deleteNode(testNode);
+	}
+
+	@Test
+	public void doNotDeleteNonInfectedOnContentUpdate() {
+		onUpdateReadScan.setDeleteOnUpdate(true);
+
+		when(nodeService.exists(testNode)).thenReturn(true);
+		when(nodeService.hasAspect(testNode, AlfviralModel.ASPECT_INFECTED)).thenReturn(false);
+
+		onUpdateReadScan.onContentUpdate(testNode, true);
+
+		verify(nodeService, Mockito.never()).deleteNode(testNode);
+	}
+}

--- a/alfviral/src/test/resources/log4j.properties
+++ b/alfviral/src/test/resources/log4j.properties
@@ -1,0 +1,11 @@
+log4j.rootLogger=DEBUG, Console
+
+###### Console appender definition #######
+
+# All outputs currently set to be a ConsoleAppender.
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+
+# use log4j NDC to replace %x with tenant domain / username
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %x %-5p [%c{3}] [%t] %m%n 
+#log4j.appender.Console.layout.ConversionPattern=%d{ABSOLUTE} %-5p [%c] %m%n


### PR DESCRIPTION
New feature: whenever a content update is processed, the node can be deleted when a virus is found

Can be activated via the feature-flag `alfviral.on_update.delete`