### PR TITLE
fixed duplicated artifact name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fegor.alfresco</groupId>
-    <artifactId>alfviral</artifactId>
+    <artifactId>alfviral-common</artifactId>
     <version>1.3.3-beta</version>
     <name>Quickstart of Alfresco and Share with DB and runner embedded</name>
     <description>This All-in-One project allows to manage all the components involved in Alfresco development (Repo, Share, Solr, AMPs) in one project</description>


### PR DESCRIPTION
The maven artifact names in `pom.xml`  and `alfviral/pom.xml` are the same (`com.fegor.alfresco:alfviral`). They have to be unique.

=> fixed the name here